### PR TITLE
Added constants for macOS 13 support

### DIFF
--- a/ECEnabler.xcodeproj/project.pbxproj
+++ b/ECEnabler.xcodeproj/project.pbxproj
@@ -363,7 +363,7 @@
 				MODULE_NAME = com.1Revenger1.ECEnabler;
 				MODULE_START = "$(PRODUCT_NAME)_kern_start";
 				MODULE_STOP = "$(PRODUCT_NAME)_kern_stop";
-				MODULE_VERSION = 1.0.2;
+				MODULE_VERSION = 1.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.1Revenger1.ECEnabler;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				RUN_CLANG_STATIC_ANALYZER = YES;
@@ -385,7 +385,7 @@
 				MODULE_NAME = com.1Revenger1.ECEnabler;
 				MODULE_START = "$(PRODUCT_NAME)_kern_start";
 				MODULE_STOP = "$(PRODUCT_NAME)_kern_stop";
-				MODULE_VERSION = 1.0.2;
+				MODULE_VERSION = 1.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.1Revenger1.ECEnabler;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				RUN_CLANG_STATIC_ANALYZER = YES;

--- a/ECEnabler/ECEStart.cpp
+++ b/ECEnabler/ECEStart.cpp
@@ -37,7 +37,7 @@ PluginConfiguration ADDPR(config) {
     bootargBeta,
     arrsize(bootargBeta),
     KernelVersion::Lion,
-    KernelVersion::Monterey,
+    KernelVersion::Ventura,
     []() {
         ece.init();
     }


### PR DESCRIPTION
Added constants for macOS 13 support

Tested by me in Ventura in Infinix X1 XL11 (This notebook need this ECEnabler.for Battery Status)